### PR TITLE
Fix links to existing github.io pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,12 +35,12 @@
         </item>
         <item>
           <h3>LÖVE-API</h3>
-          <a href="https://github.com/love2d-community/love-api"><img src="images/love-api.png"></img></a>
+          <a href="http://love2d-community.github.io/love-api"><img src="images/love-api.png"></img></a>
           <small>The complete API documentation of LÖVE contained in a lua table.</small>
         </item>
         <item>
           <h3>LÖVE Book</h3>
-          <a href="https://github.com/love2d-community/love2d-book"><img src="images/love2d-book.png"></img></a>
+          <a href="https://love2d-community.github.io/love2d-book"><img src="images/love2d-book.png"></img></a>
           <small>A book about LÖVE, Games and Lua.</small>
         </item>
         <h2>Contributions encouraged!</h2>


### PR DESCRIPTION
Why have links to github repositories, if we have working pages?